### PR TITLE
Project-wide background music with volume and fade support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,35 @@ pub struct ProjectConfig {
     pub theme: ThemeConfig,
     #[serde(default)]
     pub output: OutputConfig,
+    #[serde(default)]
+    pub audio: AudioConfig,
+}
+
+/// Project-wide audio configuration (background music, etc.)
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct AudioConfig {
+    #[serde(default)]
+    pub background: Option<BackgroundMusicConfig>,
+}
+
+/// Background music configuration for the entire project.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BackgroundMusicConfig {
+    /// Path to the background music file (supports @assets/ prefix)
+    pub file: String,
+    /// Volume in dB relative to voice (default: -12)
+    #[serde(default = "default_bg_volume")]
+    pub volume: f64,
+    /// Fade-in duration in seconds (default: 0)
+    #[serde(default)]
+    pub fade_in: f64,
+    /// Fade-out duration in seconds (default: 0)
+    #[serde(default)]
+    pub fade_out: f64,
+}
+
+fn default_bg_volume() -> f64 {
+    -12.0
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -611,6 +640,7 @@ name = "Minimal"
             },
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: AudioConfig::default(),
         };
         save_config(project_path, &config).unwrap();
         let loaded = load_config(project_path).unwrap();
@@ -635,6 +665,7 @@ name = "Minimal"
             voice: VoiceConfig::default(),
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: AudioConfig::default(),
         };
         save_config(project_path, &config).unwrap();
 
@@ -715,6 +746,7 @@ fps = 30
             voice: VoiceConfig::default(),
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: AudioConfig::default(),
         };
         save_config(project_path, &config).unwrap();
 
@@ -937,6 +969,7 @@ name = "No Parallel"
             voice: VoiceConfig::default(),
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: AudioConfig::default(),
         };
         assert!(config.validate().is_ok());
     }
@@ -955,6 +988,7 @@ name = "No Parallel"
             voice: VoiceConfig::default(),
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: AudioConfig::default(),
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("Invalid fps: 0"));
@@ -974,6 +1008,7 @@ name = "No Parallel"
             voice: VoiceConfig::default(),
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: AudioConfig::default(),
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("Invalid fps: 300"));
@@ -993,6 +1028,7 @@ name = "No Parallel"
             },
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: AudioConfig::default(),
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("padding_before"));
@@ -1012,6 +1048,7 @@ name = "No Parallel"
             },
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: AudioConfig::default(),
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("voice speed"));
@@ -1031,6 +1068,7 @@ name = "No Parallel"
             voice: VoiceConfig::default(),
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: AudioConfig::default(),
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("parallel_scenes"));
@@ -1060,6 +1098,7 @@ name = "No Parallel"
             voice: VoiceConfig::default(),
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: AudioConfig::default(),
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("width 0"));
@@ -1084,5 +1123,58 @@ name = "No Parallel"
         let p = resolve_encoding(&standard, None);
         assert_eq!(p.crf, 23);
         assert_eq!(p.audio_bitrate, "128k");
+    }
+
+    #[test]
+    fn test_background_music_config_parsing() {
+        let toml_content = r##"
+[project]
+name = "Music Test"
+
+[audio.background]
+file = "@assets/audio/bg-music.mp3"
+volume = -12
+fade_in = 2.0
+fade_out = 3.0
+"##;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("project.toml"), toml_content).unwrap();
+        let config = load_config(dir.path()).unwrap();
+        let bg = config.audio.background.unwrap();
+        assert_eq!(bg.file, "@assets/audio/bg-music.mp3");
+        assert_eq!(bg.volume, -12.0);
+        assert_eq!(bg.fade_in, 2.0);
+        assert_eq!(bg.fade_out, 3.0);
+    }
+
+    #[test]
+    fn test_background_music_config_defaults() {
+        let toml_content = r##"
+[project]
+name = "Music Default Test"
+
+[audio.background]
+file = "music.mp3"
+"##;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("project.toml"), toml_content).unwrap();
+        let config = load_config(dir.path()).unwrap();
+        let bg = config.audio.background.unwrap();
+        assert_eq!(bg.file, "music.mp3");
+        assert_eq!(bg.volume, -12.0); // default
+        assert_eq!(bg.fade_in, 0.0);  // default
+        assert_eq!(bg.fade_out, 0.0); // default
+    }
+
+    #[test]
+    fn test_no_background_music() {
+        let toml_content = r#"
+[project]
+name = "No Music"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("project.toml"), toml_content).unwrap();
+        let config = load_config(dir.path()).unwrap();
+        assert!(config.audio.background.is_none());
     }
 }

--- a/src/render/encoder.rs
+++ b/src/render/encoder.rs
@@ -564,6 +564,54 @@ pub fn burn_in_subtitles(video_path: &Path, srt_path: &Path) -> VidgenResult<()>
     Ok(())
 }
 
+/// Apply audio fade-in and/or fade-out to a video file (post-process).
+/// Used for project-wide background music fades.
+pub fn apply_audio_fades(
+    video_path: &Path,
+    total_duration: f64,
+    fade_in: f64,
+    fade_out: f64,
+) -> VidgenResult<()> {
+    if fade_in <= 0.0 && fade_out <= 0.0 {
+        return Ok(());
+    }
+
+    let tmp_path = video_path.with_extension("fade-tmp.mp4");
+    std::fs::rename(video_path, &tmp_path)?;
+
+    let mut filter_parts = Vec::new();
+    if fade_in > 0.0 {
+        filter_parts.push(format!("afade=t=in:st=0:d={fade_in:.2}"));
+    }
+    if fade_out > 0.0 {
+        let start = (total_duration - fade_out).max(0.0);
+        filter_parts.push(format!("afade=t=out:st={start:.2}:d={fade_out:.2}"));
+    }
+    let af = filter_parts.join(",");
+
+    let output = Command::new("ffmpeg")
+        .args(["-y", "-i"])
+        .arg(tmp_path.as_os_str())
+        .args(["-c:v", "copy", "-af", &af])
+        .arg(video_path.as_os_str())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| VidgenError::Ffmpeg(format!("Failed to spawn ffmpeg fade: {e}")))?;
+
+    let _ = std::fs::remove_file(&tmp_path);
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(VidgenError::Ffmpeg(format!(
+            "FFmpeg audio fade failed: {}",
+            stderr.lines().last().unwrap_or("unknown error")
+        )));
+    }
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -442,6 +442,18 @@ pub async fn render_project(
             .map(|s| apply_format_overrides(s, fmt_name))
             .collect();
 
+        // Resolve project-wide background music (if configured)
+        let project_bg_music = config.audio.background.as_ref().map(|bg| {
+            crate::scene::resolve_asset_path(&bg.file, project_path)
+        });
+        let project_bg_volume = config.audio.background.as_ref()
+            .map(|bg| {
+                // Convert dB to linear volume (0.0-1.0 range)
+                // -12dB ≈ 0.25, -6dB ≈ 0.5, 0dB = 1.0
+                10.0_f64.powf(bg.volume / 20.0)
+            })
+            .unwrap_or(0.25);
+
         // Pre-compute per-scene data (output paths, audio paths, music paths)
         let scene_prep: Vec<_> = fmt_scenes
             .iter()
@@ -449,18 +461,20 @@ pub async fn render_project(
             .map(|(i, scene)| {
                 let scene_output = fmt_temp_dir.join(format!("scene-{i:03}.mp4"));
                 let audio = audio_paths[i].clone();
+                // Scene-level music overrides project-level background music
                 let music = scene
                     .frontmatter
                     .audio
                     .as_ref()
                     .and_then(|a| a.music.as_deref())
-                    .map(|m| crate::scene::resolve_asset_path(m, project_path));
+                    .map(|m| crate::scene::resolve_asset_path(m, project_path))
+                    .or_else(|| project_bg_music.clone());
                 let music_volume = scene
                     .frontmatter
                     .audio
                     .as_ref()
                     .and_then(|a| a.music_volume)
-                    .unwrap_or(0.3);
+                    .unwrap_or(project_bg_volume);
                 (scene_output, audio, music, music_volume)
             })
             .collect();
@@ -578,6 +592,20 @@ pub async fn render_project(
             &output_path,
             &platform,
         )?;
+
+        // Apply audio fades if project-level background music has fade config
+        if let Some(ref bg) = config.audio.background {
+            let total_video_dur: f64 = effective_durations.iter().sum();
+            if bg.fade_in > 0.0 || bg.fade_out > 0.0 {
+                eprintln!(
+                    "{} Applying audio fades (in: {:.1}s, out: {:.1}s)...",
+                    "render:".cyan().bold(),
+                    bg.fade_in,
+                    bg.fade_out
+                );
+                encoder::apply_audio_fades(&output_path, total_video_dur, bg.fade_in, bg.fade_out)?;
+            }
+        }
 
         eprintln!(
             "{} Output: {}",
@@ -741,6 +769,7 @@ mod tests {
             voice: VoiceConfig::default(),
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: crate::config::AudioConfig::default(),
         };
         let result = resolve_formats(&config, None);
         assert_eq!(result.len(), 2);
@@ -767,6 +796,7 @@ mod tests {
             voice: VoiceConfig::default(),
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: crate::config::AudioConfig::default(),
         };
         let result = resolve_formats(&config, None);
         assert_eq!(result.len(), 1);
@@ -819,6 +849,7 @@ mod tests {
             voice: VoiceConfig::default(),
             theme: ThemeConfig::default(),
             output: OutputConfig::default(),
+            audio: crate::config::AudioConfig::default(),
         };
         let filter = vec!["portrait".into(), "square".into()];
         let result = resolve_formats(&config, Some(&filter));


### PR DESCRIPTION
## Summary
- New `[audio.background]` config section in `project.toml`:
  - `file`: path to music file (@assets/ prefix supported)
  - `volume`: dB relative to voice (default: -12dB)
  - `fade_in`/`fade_out`: seconds (default: 0)
- Project-level music applies to all scenes, overridable per-scene
- dB-to-linear volume conversion for FFmpeg filters
- Fade applied as post-process via `afade` (video stream copied, only audio re-encoded)

## Test plan
- [x] 187 unit tests pass (3 new: config parsing, defaults, no-music)
- [ ] Smoke test with background music file in project

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)